### PR TITLE
fix storage size

### DIFF
--- a/AskSinMain.cpp
+++ b/AskSinMain.cpp
@@ -319,7 +319,7 @@ void     HM::regCnlModule(uint8_t cnl, s_mod_dlgt Delegate, uint16_t *mainList, 
 }
 
 uint32_t HM::getHMID(void) {
-	uint8_t a[3];
+	uint8_t a[4];
 	a[0] = hmId[2];
 	a[1] = hmId[1];
 	a[2] = hmId[0];


### PR DESCRIPTION
Hallo Dirk,

ich bin gerade dabei, die AskSin / NewAskSin auf eigene Sensor-Hardware zu bringen.
Dabei ist mir der Fehler hier aufgefallen.
Könnte im ungünstigsten Fall zu fehlerhaften Daten / ungültigen Rücksprungadressen führen.
Bei mir gab's eine falsche HMID zurück (a[3] war nicht 0).

Viele Grüße,
Martin
